### PR TITLE
support for custom CA secret

### DIFF
--- a/stable/openldap/templates/deployment.yaml
+++ b/stable/openldap/templates/deployment.yaml
@@ -52,6 +52,15 @@ spec:
               mountPath: /tls
             - name: certs
               mountPath: /certs
+        {{- if .Values.tls.CA.enabled }}
+        - name: {{ .Chart.Name }}-catls
+          image: busybox
+          command: ['sh', '-c', 'cp /catls/ca.crt /certs; while true; do sleep 10000; done']
+          volumeMounts:
+            - name: catls
+              mountPath: /catls
+            - name: certs
+              mountPath: /certs
         {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -70,6 +79,10 @@ spec:
               value: tls.crt
             - name: LDAP_TLS_KEY_FILENAME
               value: tls.key
+            {{- if .Values.tls.CA.enabled }}
+            - name: LDAP_TLS_CA_CRT_FILENAME
+              value: ca.crt
+            {{- end }}
           {{- end }}
           envFrom:
             - configMapRef:
@@ -129,6 +142,11 @@ spec:
         - name: tls
           secret:
             secretName: {{ .Values.tls.secret }}
+        {{- if .Values.tls.CA.enabled }}
+        - name: catls
+          secret:
+            secretName: {{ .Values.tls.CA.secret }}
+        {{- end }}
         - name: certs
           emptyDir:
             medium: Memory

--- a/stable/openldap/values.yaml
+++ b/stable/openldap/values.yaml
@@ -29,7 +29,9 @@ existingSecret: ""
 tls:
   enabled: false
   secret: ""  # The name of a kubernetes.io/tls type secret to use for TLS
-
+  CA:
+    enabled: false
+    secret: "" # The name of a generic secret to use for custom CA certificate (ca.crt)
 ## Add additional labels to all resources
 extraLabels: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Provide values to add a custom CA certificate as [docker-openldap](https://github.com/osixia/docker-openldap#use-your-own-certificate) specification
`--env LDAP_TLS_CA_CRT_FILENAME=ca.crt`
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #11719

#### Special notes for your reviewer:
- maybe there is a best way to achieve this(?)
- version is still 0.4.0
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
